### PR TITLE
cleared some vagrant-windows keywords, add ssh port forwarding

### DIFF
--- a/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
- 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-datacenter.tpl
+++ b/tpl/vagrantfile-win2008r2-datacenter.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
- 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-enterprise.tpl
+++ b/tpl/vagrantfile-win2008r2-enterprise.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
- 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-standard-cygwin.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-standard.tpl
+++ b/tpl/vagrantfile-win2008r2-standard.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-web-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-web-cygwin.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2008r2-web.tpl
+++ b/tpl/vagrantfile-win2008r2-web.tpl
@@ -9,13 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2012-datacenter-cygwin.tpl
@@ -8,11 +8,13 @@ Vagrant.configure("2") do |config|
     # Port forward WinRM and RDP
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
-    config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true 
-  
+    config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012-datacenter.tpl
+++ b/tpl/vagrantfile-win2012-datacenter.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2012-standard-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012-standard.tpl
+++ b/tpl/vagrantfile-win2012-standard.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true 
-  
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-  
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012r2-datacenter.tpl
+++ b/tpl/vagrantfile-win2012r2-datacenter.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-  
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2012r2-standard-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-  
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win2012r2-standard.tpl
+++ b/tpl/vagrantfile-win2012r2-standard.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-  
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+     # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x64-enterprise.tpl
+++ b/tpl/vagrantfile-win7x64-enterprise.tpl
@@ -9,14 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
 
-    config.vm.guest = :windows
-    config.windows.halt_timeout = 15
-    config.windows.set_work_network = true
- 
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x64-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win7x64-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x64-pro.tpl
+++ b/tpl/vagrantfile-win7x64-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl
@@ -9,12 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
-    # Ensure that all networks are set to private
-    config.windows.set_work_network = true
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
  
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x86-enterprise.tpl
+++ b/tpl/vagrantfile-win7x86-enterprise.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x86-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win7x86-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win7x86-pro.tpl
+++ b/tpl/vagrantfile-win7x86-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x64-enterprise.tpl
+++ b/tpl/vagrantfile-win81x64-enterprise.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x64-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win81x64-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x64-pro.tpl
+++ b/tpl/vagrantfile-win81x64-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x86-enterprise.tpl
+++ b/tpl/vagrantfile-win81x86-enterprise.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x86-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win81x86-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win81x86-pro.tpl
+++ b/tpl/vagrantfile-win81x86-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win8x64-enterprise-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x64-enterprise.tpl
+++ b/tpl/vagrantfile-win8x64-enterprise.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x64-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win8x64-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x64-pro.tpl
+++ b/tpl/vagrantfile-win8x64-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win8x86-enterprise-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x86-enterprise.tpl
+++ b/tpl/vagrantfile-win8x86-enterprise.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x86-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win8x86-pro-cygwin.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]

--- a/tpl/vagrantfile-win8x86-pro.tpl
+++ b/tpl/vagrantfile-win8x86-pro.tpl
@@ -9,10 +9,12 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
     config.vm.communicator = "winrm"
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct:true
- 
+    # Port forward SSH
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct:true
+
     # Berkshelf
     # config.berkshelf.enabled = true
-  
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 768]


### PR DESCRIPTION
I have removed some keywords that have been used by the vagrant-windows plugin.
The template vagrantfiles already have the `config.vm.communicator = "winrm"` to use Vagrants new winrm communicator. So it is time to cleanup such old keywords and users then don't need to install the vagrant-windows plugin.

But as the OpenSSH or Cygwin sshd are installed and keep installed after building the base box, we also should add the SSH port forwarding. Vagrant 1.6.2 with winrm communicator only auto forwards the winrm port 5985, but no longer the ssh port 22.
So it is useful to add the port forwarding in the base boxes that still have a windows SSH service running.

For future boxes without a windows SSH service, the ssh port forwarding could be removed.  

A small test with a Windows 7 Enterprise works fine without the vagrant-vcloud plugin and only using Vagrant 1.6.2 with VirtualBox 4.3.10.

My sample Vagrantfile is this, I could have skipped the winrm line. The network will be set to work network with Vagrant 1.6.2. Everything looks fine.

``` ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

VAGRANTFILE_API_VERSION = "2"

Vagrant.require_version ">= 1.6.0"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box      = "win7x64-enterprise"
  config.vm.hostname = "win7"
  config.vm.communicator = "winrm"
  config.vm.network :private_network, ip: "192.168.33.237"

  config.vm.provider :virtualbox do |vb|
    vb.gui = true
    vb.customize ["modifyvm", :id, "--memory", 768]
    vb.customize ["modifyvm", :id, "--cpus", 1]
    vb.customize ["modifyvm", :id, "--vram", "32"]
    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
    vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
  end

  config.vm.provision "shell", path: "provision.ps1"
end
```

And the shell provision.ps1 script is this:

``` ps1
Write-Host This is computer $env:COMPUTERNAME
```

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'win7x64-enterprise'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: tst_default_1400508530827_18902
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 3389 => 3389 (adapter 1)
    default: 5985 => 5985 (adapter 1)
    default: 22 => 2222 (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /vagrant => /Users/stefan/code/vpn/tst
==> default: Running provisioner: shell...
    default: Running: c:\tmp\vagrant-shell.ps1
==> default: This is computer WINDOWS-AHN8UJX
```

The hostname is changed by vagrant, but the guest needs a reboot to finally have the hostname from the Vagrantfile.
