### PR TITLE
Win sysprep

### DIFF
--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -6,6 +6,7 @@
     "iso_url": "http://iso.esd.microsoft.com/W9TPI/B6B0A0278A90510669EAB90ABF80B22A/Windows10_TechnicalPreview_x64_EN-US_9926.iso",
     "iso_checksum": "6a95316728299d95249a29fbeb9676ded23b8beb",
     "update": true,
+    "sysprep": "true",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -21,6 +22,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -55,6 +57,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -88,6 +91,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -116,7 +120,8 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
@@ -126,7 +131,8 @@
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -6,7 +6,8 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
-    "update": true
+    "update": true,
+    "sysprep": "true"
   },
   "builders": [
     {
@@ -20,6 +21,7 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -57,6 +59,7 @@
       "disk_size": 40960,
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",        
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -92,6 +95,7 @@
       "disk_size": 40960,
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",        
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -122,7 +126,8 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
@@ -132,7 +137,8 @@
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -6,6 +6,7 @@
     "iso_url": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_ENTERPRISE_EVAL_EN-US-IRM_CENA_X64FREE_EN-US_DV5.ISO",
     "iso_checksum": "73321fa912305e5a16096ef62380a91ee1f112da",
     "update": true,
+    "sysprep": "false",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -21,6 +22,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -55,6 +57,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -62,7 +65,6 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
-        "floppy/update.bat",
         "floppy/disablewinupdate.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
@@ -88,6 +90,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -116,13 +119,15 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "script/vagrant.bat",
         "script/cmtool.bat",
         "script/vmtool.bat",
+        "script/sysprep-generalize.bat",
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -127,11 +127,11 @@
         "script/vagrant.bat",
         "script/cmtool.bat",
         "script/vmtool.bat",
-        "script/sysprep-generalize.bat",
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/floppy/sysprep/unattend.xml
+++ b/floppy/sysprep/unattend.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>3</ProtectYourPC>
+                <HideEULAPage>true</HideEULAPage>
+            </OOBE>
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>dgBhAGcAcgBhAG4AdABQAGEAcwBzAHcAbwByAGQA</Value>
+                            <PlainText>false</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <Name>vagrant</Name>
+                        <DisplayName>vagrant</DisplayName>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <TimeZone>Pacific Standard Time</TimeZone>
+        </component>
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ComputerName>*</ComputerName>
+        </component>
+    </settings>
+</unattend>

--- a/script/sysprep-generalize.bat
+++ b/script/sysprep-generalize.bat
@@ -1,0 +1,33 @@
+@ECHO OFF
+@ECHO ==^> Running sysprep if requested in template file...
+@echo %SYSPREP% | findstr /I "true"
+@if errorlevel 1 GOTO :eof
+
+@ECHO ==^> Copying unattend.xml to sysprep directory
+@COPY /Y A:\unattend.xml %WINDIR%\system32\sysprep
+@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: COPY command
+
+@ECHO ==^> Running sysprep /oobe /generalize with Unattend file
+@PUSHD %WINDIR%\system32\sysprep
+
+:: Credit to http://stackoverflow.com/questions/4808847/how-to-compare-windows-versions-in-a-batch-script
+@set Version=
+@for /f "skip=1" %%v in ('wmic os get version') do if not defined Version set Version=%%v
+@for /f "delims=. tokens=1-3" %%a in ("%Version%") do (
+  @set Version.Major=%%a
+  @set Version.Minor=%%b
+  @set Version.Build=%%c
+)
+@ECHO ==^> Checking OS Version for sysprep command parameters
+@if %Version.Major% EQU 6 if %Version.Minor% GEQ 2 (
+  @ECHO ==^> Windows 8 Kernel or higher found, supports /mode:vm
+  sysprep.exe /oobe /generalize /mode:vm /quit
+)
+@if %Version.Major% EQU 6 if %Version.Minor% LEQ 1 (
+  @ECHO ==^> Windows 7 Kernel found
+  sysprep.exe /oobe /generalize /quit
+)
+@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: sysprep.exe
+
+:eof 
+@exit /b %ERRORLEVEL%

--- a/script/sysprep-generalize.bat
+++ b/script/sysprep-generalize.bat
@@ -13,7 +13,7 @@
 @COPY /Y A:\unattend.xml %WINDIR%\system32\sysprep
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: COPY command
 
-@ECHO ==^> Running sysprep /oobe /generalize with Unattend file
+@ECHO ==^> Running sysprep /oobe /generalize with unattend.xml file
 @PUSHD %WINDIR%\system32\sysprep
 
 :: Credit to http://stackoverflow.com/questions/4808847/how-to-compare-windows-versions-in-a-batch-script
@@ -25,15 +25,20 @@
   @set Version.Build=%%c
 )
 @ECHO ==^> Checking OS Version for sysprep command parameters
-@if %Version.Major% EQU 6 if %Version.Minor% GEQ 2 (
+@if %Version.Major% GEQ 7 GOTO :modevm
+@if %Version.Major% EQU 6 if %Version.Minor% GEQ 2 GOTO :modevm
+@if %Version.Major% EQU 6 if %Version.Minor% LEQ 1 GOTO :generalize
+
+:modevm
   @ECHO ==^> Windows 8 Kernel or higher found, supports /mode:vm
   sysprep.exe /oobe /generalize /mode:vm /quit
-)
-@if %Version.Major% EQU 6 if %Version.Minor% LEQ 1 (
+  GOTO :eof
+
+:generalize
   @ECHO ==^> Windows 7 Kernel found
   sysprep.exe /oobe /generalize /quit
-)
-@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: sysprep.exe
+  GOTO :eof
 
 :eof 
+@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: sysprep.exe
 @exit /b %ERRORLEVEL%

--- a/script/sysprep-generalize.bat
+++ b/script/sysprep-generalize.bat
@@ -1,20 +1,20 @@
-@ECHO OFF
-@ECHO ==^> Running sysprep if requested in template file...
+@echo OFF
+@echo ==^> Running sysprep if requested in template file...
 @if not defined sysprep ( 
-  @ECHO ==^> No sysprep variable defined, exiting
-  GOTO :eof
+  @echo ==^> No sysprep variable defined, exiting
+  @goto :eof
 )
 @echo %SYSPREP% | findstr /I "true"
 @if errorlevel 1 (
-  @ECHO ==^> Sysprep variable not set to true, exiting
-  GOTO :eof
+  @echo ==^> Sysprep variable not set to true, exiting
+  @goto :eof
 )
-@ECHO ==^> Copying unattend.xml to sysprep directory
-@COPY /Y A:\unattend.xml %WINDIR%\system32\sysprep
+@echo ==^> Copying unattend.xml to sysprep directory
+@copy /Y A:\unattend.xml %WINDIR%\system32\sysprep
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: COPY command
 
-@ECHO ==^> Running sysprep /oobe /generalize with unattend.xml file
-@PUSHD %WINDIR%\system32\sysprep
+@echo ==^> Running sysprep /oobe /generalize with unattend.xml file
+@pushd %WINDIR%\system32\sysprep
 
 :: Credit to http://stackoverflow.com/questions/4808847/how-to-compare-windows-versions-in-a-batch-script
 @set Version=
@@ -24,20 +24,20 @@
   @set Version.Minor=%%b
   @set Version.Build=%%c
 )
-@ECHO ==^> Checking OS Version for sysprep command parameters
-@if %Version.Major% GEQ 7 GOTO :modevm
-@if %Version.Major% EQU 6 if %Version.Minor% GEQ 2 GOTO :modevm
-@if %Version.Major% EQU 6 if %Version.Minor% LEQ 1 GOTO :generalize
+@echo ==^> Checking OS Version for sysprep command parameters
+@if %Version.Major% GEQ 7 goto :modevm
+@if %Version.Major% EQU 6 if %Version.Minor% GEQ 2 goto :modevm
+@if %Version.Major% EQU 6 if %Version.Minor% LEQ 1 goto :generalize
 
 :modevm
-  @ECHO ==^> Windows 8 Kernel or higher found, supports /mode:vm
+  @echo ==^> Windows 8 Kernel or higher found, supports /mode:vm
   sysprep.exe /oobe /generalize /mode:vm /quit
-  GOTO :eof
+  @goto :eof
 
 :generalize
-  @ECHO ==^> Windows 7 Kernel found
+  @echo ==^> Windows 7 Kernel found
   sysprep.exe /oobe /generalize /quit
-  GOTO :eof
+  @goto :eof
 
 :eof 
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: sysprep.exe

--- a/script/sysprep-generalize.bat
+++ b/script/sysprep-generalize.bat
@@ -1,8 +1,14 @@
 @ECHO OFF
 @ECHO ==^> Running sysprep if requested in template file...
+@if not defined sysprep ( 
+  @ECHO ==^> No sysprep variable defined, exiting
+  GOTO :eof
+)
 @echo %SYSPREP% | findstr /I "true"
-@if errorlevel 1 GOTO :eof
-
+@if errorlevel 1 (
+  @ECHO ==^> Sysprep variable not set to true, exiting
+  GOTO :eof
+)
 @ECHO ==^> Copying unattend.xml to sysprep directory
 @COPY /Y A:\unattend.xml %WINDIR%\system32\sysprep
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: COPY command

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -6,7 +6,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "update": true,
-    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
+    "sysprep": "true",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -120,7 +120,8 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -5,8 +5,9 @@
     "cm_version": "",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
-    "update": true
+    "update": true,
+    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
     {
@@ -20,6 +21,7 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -55,6 +57,7 @@
       "disk_size": 40960,
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -88,6 +91,7 @@
       "disk_size": 40960,
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/fixnetwork.ps1",
@@ -126,7 +130,8 @@
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -6,7 +6,7 @@
     "iso_url": "./iso/SW_DVD5_SA_Win_Ent_8.1_64BIT_English_MLF_X18-96759.ISO",
     "iso_checksum": "8e194185fcce4ea737f274ee9005ddf0",
     "update": true,
-    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
+    "sysprep": "true",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -3,9 +3,10 @@
     "version": "0.1.0",
     "cm": "chef",
     "cm_version": "",
-    "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
-    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "iso_url": "./iso/SW_DVD5_SA_Win_Ent_8.1_64BIT_English_MLF_X18-96759.ISO",
+    "iso_checksum": "8e194185fcce4ea737f274ee9005ddf0",
     "update": true,
+    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -15,12 +16,13 @@
       "guest_os_type": "windows8-64",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "sha1",
+      "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -47,12 +49,13 @@
       "guest_os_type": "Windows8_64",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "sha1",
+      "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -67,7 +70,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "disk_size": 40960,
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--memory", "1536"],
+        ["modifyvm", "{{.Name}}", "--memory", "2048"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"],
         ["setextradata", "{{.Name}}", "VBoxInternal/CPUM/CMPXCHG16B", "1"]
       ]
@@ -78,12 +81,13 @@
       "guest_os_type": "win-8.1",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "sha1",
+      "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -110,17 +114,18 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}",
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "script/vagrant.bat",
         "script/cmtool.bat",
         "script/vmtool.bat",
-        "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
         "script/sdelete.bat"
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -115,7 +115,7 @@
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}",
-        "SYSPREP={{user `sysprep`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
@@ -124,7 +124,7 @@
         "script/vmtool.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
         "script/sysprep-generalize.bat"
       ]
     },

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -6,6 +6,7 @@
     "iso_url": "iso/en_windows_8_enterprise_x64_dvd_917522.iso",
     "iso_checksum": "4eadfe83e736621234c63e8465986f0af6aa3c82",
     "update": true,
+    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -20,6 +21,7 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -52,6 +54,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -82,6 +85,7 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/sysprep/unattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/install-winrm.cmd",
         "floppy/powerconfig.bat",
@@ -118,7 +122,8 @@
         "script/clean.bat",
         "script/ultradefrag.bat",
         "script/uninstall-7zip.bat",
-        "script/sdelete.bat"
+        "script/sdelete.bat",
+        "script/sysprep-generalize.bat"
       ]
     },
     {

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -3,10 +3,10 @@
     "version": "0.1.0",
     "cm": "chef",
     "cm_version": "",
-    "iso_url": "iso/en_windows_8_enterprise_x64_dvd_917522.iso",
+    "iso_url": "iso/SW_DVD5_SA_Win_Ent_8_64BIT_English_Full_MLF_X18-16254.ISO",
     "iso_checksum": "4eadfe83e736621234c63e8465986f0af6aa3c82",
     "update": true,
-    "sysprep": "youcanliterallyputanythinghereyouwantaslongasthevariableisdefined",
+    "sysprep": "true",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'"
   },
   "builders": [
@@ -112,7 +112,8 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
-        "UPDATE={{user `update`}}"
+        "UPDATE={{user `update`}}",
+        "SYSPREP={{user `sysprep`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [


### PR DESCRIPTION
This is most of the work to get sysprep working. The only case I have seen where this doesn't work is when using the Win10 CTP. This is due to the post-sysprep requiring you enter a licensing key that is tied to the evaluation download ISO. You could tweak the unattend.xml file and explicitly list the key there to get around this issue.
I have tested this in VMWare and Virtualbox, but unfortunately do not have access to parallels. 
Happy to add this to all the templates if that is what you guys desire =)
